### PR TITLE
Memory leak in min_snp_sep

### DIFF
--- a/R/hmm_ibd.R
+++ b/R/hmm_ibd.R
@@ -67,7 +67,7 @@ hmm_ibd <- function(input_file,
                     max_discord = 1,
                     nchrom = 14,
                     min_snp_sep = 5,
-                    rec_rate = 7.4-7) {
+                    rec_rate = 7.4e-7) {
 
 
   files <- grep(basename(output_file),

--- a/R/hmm_ibd.R
+++ b/R/hmm_ibd.R
@@ -67,7 +67,7 @@ hmm_ibd <- function(input_file,
                     max_discord = 1,
                     nchrom = 14,
                     min_snp_sep = 5,
-                    rec_rate = 7.47e-5) {
+                    rec_rate = 7.4-7) {
 
 
   files <- grep(basename(output_file),

--- a/man/hmm_ibd.Rd
+++ b/man/hmm_ibd.Rd
@@ -22,7 +22,7 @@ hmm_ibd(
   max_discord = 1,
   nchrom = 14,
   min_snp_sep = 5,
-  rec_rate = 7.47e-05
+  rec_rate = 7.4 - 7
 )
 }
 \arguments{

--- a/src/hmmIBD.cpp
+++ b/src/hmmIBD.cpp
@@ -24,7 +24,7 @@ int hmmibd_c(Rcpp::List param_list) {
   double min_discord = Rcpp::as<double>(param_list["min_discord"]); // minimum discordance in comparison; set > 0 to skip identical pairs
   double max_discord = Rcpp::as<double>(param_list["max_discord"]); // set < 1 to skip unrelated pairs
   int nchrom = Rcpp::as<int>(param_list["nchrom"]); // 14 for falciparum
-  double min_snp_sep = Rcpp::as<double>(param_list["min_snp_sep"]); // skip next snp(s) if too close to last one; in bp
+  int min_snp_sep = Rcpp::as<int>(param_list["min_snp_sep"]); // skip next snp(s) if too close to last one; in bp
   double rec_rate = Rcpp::as<double>(param_list["rec_rate"]); // 7.4e-5 cM/bp or 13.5 kb/cM Miles et al, Genome Res 26:1288-1299 (2016)
   //  const double rec_rate = 5.8e-7;   // 5.8e-5 cM/bp, or 17kb/cM
 


### PR DESCRIPTION
When min_snp_sep was being imported as an double instead of int, it was pulling a random number from memory (see attached image). Quick change to int fixes this issue. 

Also changed the default rec_rate to 7.4e-7 from 7.47e-5 to account for M vs cM. The former is more in line with the original paper/original model formulation (unless SNP dist is coded differently by the user)
![Screen Shot 2020-02-03 at 10 39 02 AM](https://user-images.githubusercontent.com/12299990/73672589-2c842180-467b-11ea-9a8a-652a5d15dabb.png)
